### PR TITLE
chore(devcontainer): add the WakaTime extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,9 @@
   "workspaceFolder": "/home/bun/app",
   "shutdownAction": "stopCompose",
   "remoteUser": "bun",
+  "remoteEnv": {
+    "WAKATIME_API_KEY": "${localEnv:WAKATIME_API_KEY}"
+  },
   "mounts": [
     "source=${env:HOME}/home/bun/.ssh,target=/.ssh,type=bind,consistency=cached,readonly"
   ],
@@ -33,6 +36,7 @@
         "GitHub.copilot",
         "GitHub.copilot-chat",
         "PKief.material-icon-theme",
+        "WakaTime.vscode-wakatime",
         "antfu.file-nesting",
         "bierner.markdown-mermaid",
         "bierner.markdown-preview-github-styles",


### PR DESCRIPTION
## What
`.devcontainer/devcontainer.json` に `WakaTime.vscode-wakatime` を追加した。
あわせて \`remoteEnv\` に \`WAKATIME_API_KEY\` の受け渡しを追加した。

## Why
Dev Container を使っている全リポジトリでコーディング時間を計測できるようにするため。

## Test plan
Dev Container をリビルドして WakaTime 拡張が入ることを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)